### PR TITLE
Add CI pipeline that builds the spec using GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image:$(date +%s)
+
+    - name: Run the Docker container
+      run: |
+        docker run my-image:$(date +%s) --name test-container
+
+    - name: Check container status
+      run: docker ps -a

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,16 +21,16 @@ jobs:
       with:
         context: .
         file: Dockerfile
-        tags: my-image:latest
+        tags: omg-mdsa-build:latest
         load: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
     - name: Run the Docker container
-      run: docker run --name build-container my-image:latest
+      run: docker run --name omg-mdsa-build-container omg-mdsa-build:latest
 
     - name: Copy PDF from container
-      run: docker cp build-container:/app/. ./output/
+      run: docker cp omg-mdsa-build-container:/app/. ./output/
 
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       run: docker build . --file Dockerfile --tag my-image:latest
 
     - name: Run the Docker container
-      run: docker run my-image:latest --name test-container
+      run: docker run my-image:latest
 
     - name: Check container status
       run: docker ps -a

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag my-image:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,11 +12,10 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image:$(date +%s)
+      run: docker build . --file Dockerfile --tag my-image:latest
 
     - name: Run the Docker container
-      run: |
-        docker run my-image:$(date +%s) --name test-container
+      run: docker run my-image:latest --name test-container
 
     - name: Check container status
       run: docker ps -a

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,18 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image:latest
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile
+        tags: my-image:latest
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Run the Docker container
       run: docker run --name build-container my-image:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,17 @@ jobs:
       run: docker build . --file Dockerfile --tag my-image:latest
 
     - name: Run the Docker container
-      run: docker run my-image:latest
+      run: docker run --name build-container my-image:latest
 
-    - name: Check container status
-      run: docker ps -a
+    - name: Copy PDF from container
+      run: docker cp build-container:/app/. ./output/
+
+    - name: Upload PDF artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: specification-pdf
+        path: output/*.pdf
+
+    - name: Remove container
+      if: always()
+      run: docker rm build-container

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,3 @@ jobs:
       with:
         name: specification-pdf
         path: output/*.pdf
-
-    - name: Remove container
-      if: always()
-      run: docker rm build-container

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,9 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   make \
   git \
-  texlive \
-  latexmk \
+  texlive-full \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-RUN tlmgr init-usertree
-RUN tlmgr install enumitem everypage svg transparent draftwatermark
 
 # Set working directory
 WORKDIR /app
@@ -20,4 +16,4 @@ WORKDIR /app
 COPY . .
 
 # Default command
-CMD ["make"]
+CMD ["make", "debug"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.9-slim
+
+# Install necessary build tools and dependencies
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  make \
+  git \
+  texlive \
+  latexmk \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN tlmgr init-usertree
+RUN tlmgr install enumitem everypage svg transparent draftwatermark
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files (you can adjust this according to your needs)
+COPY . .
+
+# Default command
+CMD ["make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.9-slim
 
 RUN apt-get update && apt-get install -y \
   make \
+  git \
   pandoc \
   biber \
   latexmk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM python:3.9-slim
 
-# Install necessary build tools and dependencies
 RUN apt-get update && apt-get install -y \
-  build-essential \
   make \
-  git \
-  texlive-full \
+  pandoc \
+  biber \
+  latexmk \
+  texlive-latex-base \
+  texlive-latex-recommended \
+  texlive-latex-extra \
+  texlive-fonts-recommended \
+  texlive-bibtex-extra \
+  texlive-xetex \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
   texlive-latex-extra \
   texlive-fonts-recommended \
   texlive-bibtex-extra \
+  texlive-pictures \
   texlive-xetex \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ WORKDIR /app
 COPY . .
 
 # Default command
-CMD ["make", "debug"]
+CMD ["make"]


### PR DESCRIPTION
@jasonmccsmith my colleague @barmac came up with a initial draft of a `Dockerfile` to install and run TeX Live.

Could you have a look at the build output and review if the LaTeX environment is set up correctly?

The dependencies installed in the Debian-based environment could probably be simplified to speed up the build, e.g. currently we install the `texlive-full` package resulting in a Docker image of over 5 GiB.

The GitHub Action workflow still needs to be changed to store the resulting PDF.

@omgtechdir FYI